### PR TITLE
clarify that motion controls are on Monitor Advanced view

### DIFF
--- a/web/data/motion.json
+++ b/web/data/motion.json
@@ -72,7 +72,7 @@
                         "code":"pm2 start plugins/motion/shinobi-motion.js"
                     },
                     {
-                        "text":"When complete you will see <code>Detector : Motion Connected</code> in your Monitor Settings. Shinobi does not need to be restarted unless you modified the <code>PluginKeys</code> in <code>conf.json</code>"
+                        "text":"When complete you will see <code>Detector : Motion Connected</code> in the Advanced view of your Monitor Settings. Shinobi does not need to be restarted unless you modified the <code>PluginKeys</code> in <code>conf.json</code>"
                     }
                 ]
             }


### PR DESCRIPTION
I spent a full 5 or 6 hours reinstalling over and over again trying to test out Shinobi and get motion detection working. I only figured it out because I stumbled on a forum post that mentioned something about "Advanced" for monitors... it had never occurred to me to look there, and none of the docs that I read told me to.

Add some clarification so hopefully others won't have this experience.